### PR TITLE
fixed few bugs

### DIFF
--- a/{{cookiecutter.project_slug}}/config/hooks/pre-commit
+++ b/{{cookiecutter.project_slug}}/config/hooks/pre-commit
@@ -4,7 +4,7 @@
 set -e
 
 # flake8 linting
-flake8 --ignore D --max-line-length=100 .  # Check everything but docstrings
+flake8 --ignore D,W503 --max-line-length=100 .  # Check everything but docstrings
 flake8 --select D --ignore D104,D100,D401 --docstring-convention google --exclude tests/  # Check only the docstrings
 
 # Raise error if any staged notebooks contain outputs

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -35,7 +35,7 @@ setup(
         'scipy==1.4.1',
         'setuptools>=41.0.0',
         'six>=1.12.0',
-        'numpy==1.19.4'],
+        'numpy>=1.19.4'],
         {%- endif %}
     entry_points={
         'console_scripts': [

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/main.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/main.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 import mlflow
+import orion
 import yaml
 from yaml import load
 
@@ -85,8 +86,13 @@ def main():
         hyper_params = {}
 
     # to be done as soon as possible otherwise mlflow will not log with the proper exp. name
-    if 'exp_name' in hyper_params:
-        mlflow.set_experiment(hyper_params['exp_name'])
+
+    if orion.client.cli.IS_ORION_ON:
+        exp_name = os.getenv('ORION_EXPERIMENT_NAME', 'orion_exp')
+    else:
+        exp_name = hyper_params.get('exp_name', 'exp')
+    mlflow.set_experiment(exp_name)
+
     if os.path.exists(os.path.join(args.output, STAT_FILE_NAME)):
         _, _, _, mlflow_run_id = load_stats(args.output)
         mlflow.start_run(run_id=mlflow_run_id)

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/train.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/train.py
@@ -127,7 +127,7 @@ def train(model, optimizer, loss_fun, train_loader, dev_loader, patience, output
             model, optimizer, loss_fun, train_loader, dev_loader, patience, output,
             max_epoch, use_progress_bar, start_from_scratch)
     except RuntimeError as err:
-        if orion.client.IS_ORION_ON and 'CUDA out of memory' in str(err):
+        if orion.client.cli.IS_ORION_ON and 'CUDA out of memory' in str(err):
             logger.error(err)
             logger.error('model was out of memory - assigning a bad score to tell Orion to avoid'
                          'too big model')


### PR DESCRIPTION
* the command to check if Orion is working changed from `orion.client...` to `orion.client.cli...`.
* when running Orion, the exp name should be the Orion exp name, not the one in config (that will instead change with every trial).
* removed the warning W503 in flake8 (see also https://www.flake8rules.com/rules/W503.html).