### PR TITLE
Update end2end test

### DIFF
--- a/tests/end2end_pytorch/run.sh
+++ b/tests/end2end_pytorch/run.sh
@@ -8,8 +8,8 @@ cookiecutter ../.. --no-input --output-dir=./
 cd wonderful_project
 git init
 # setting some fake name/email for git:
-git config --global user.email "you@example.com"
-git config --global user.name "Your Name"
+git config user.email "you@example.com"
+git config user.name "Your Name"
 git add -A
 git commit -m "initial commit"
 pip install -e . --quiet


### PR DESCRIPTION
Sets the git username for the project, not globally, avoids resetting the username when run locally