### PR TITLE
Copy output folder to tmp_folder on cluster

### DIFF
--- a/amlrt_project/train.py
+++ b/amlrt_project/train.py
@@ -73,6 +73,8 @@ def main():
         output_dir = os.path.join(args.tmp_folder, 'output')
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
+        if os.path.exists(args.output):
+            rsync_folder(args.output, args.tmp_folder)
     else:
         data_dir = args.data
         output_dir = args.output


### PR DESCRIPTION
Currently, the output folder and the best_model inside it do not get copied in the tmp_folder on the cluster, therefore model training does not resume as expected. Proposed fix: copy the output_dir in tmp_folder at initialization.