### PR TITLE
split end2end tests into 2 components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,12 @@ jobs:
     - name: unit tests
       run: |
         pytest --cov=amlrt-project
-    - name: pytorch-end2end
+    - name: pytorch-end2end-single
       run: |
-        ./tests/end2end_pytorch/run.sh
+        ./tests/end2end_pytorch/run_single.sh
+    - name: pytorch-end2end-orion
+      run: |
+        ./tests/end2end_pytorch/run_orion.sh
     - name: type checking
       run: |
         pytype amlrt_project/

--- a/examples/local/config.yaml
+++ b/examples/local/config.yaml
@@ -1,2 +1,5 @@
+# note how this param is overriding the parent config one (check folder above)
+max_epoch: 2
+
 # architecture
 hidden_dim: 256

--- a/examples/local/eval.sh
+++ b/examples/local/eval.sh
@@ -1,0 +1,1 @@
+amlrt-eval --data ../data --config ../config.yaml config.yaml --ckpt-path output/best_model/model.ckpt

--- a/examples/local/run.sh
+++ b/examples/local/run.sh
@@ -1,3 +1,1 @@
-set -e
 amlrt-train --data ../data --output output --config ../config.yaml config.yaml --start-from-scratch
-amlrt-eval --data ../data --config ../config.yaml config.yaml --ckpt-path output/best_model/model.ckpt

--- a/tests/end2end_pytorch/run_orion.sh
+++ b/tests/end2end_pytorch/run_orion.sh
@@ -2,23 +2,6 @@
 set -e
 
 # go to the examples folder and run the example
-cd $GITHUB_WORKSPACE/examples/local
-sh run.sh
-mv output output_OLD
-# re-run the example to check reproducibility
-sh run.sh
-# check results are the same
-echo "results are:"
-cat output*/results.txt
-DIFF_LINES=`cat output*/results.txt | uniq | wc -l`
-if [ ${DIFF_LINES} -gt 1 ]; then
-    echo "ERROR: two identical runs produced different output results - review seed implementation"
-    exit 1
-else
-    echo "PASS: two identical runs produced the same output results."
-fi
-
-# run Orion
 cd $GITHUB_WORKSPACE/examples/local_orion
 sh run.sh
 mv orion_working_dir orion_working_dir_OLD

--- a/tests/end2end_pytorch/run_single.sh
+++ b/tests/end2end_pytorch/run_single.sh
@@ -17,3 +17,16 @@ if [ ${DIFF_LINES} -gt 1 ]; then
 else
     echo "PASS: two identical runs produced the same output results."
 fi
+
+# now run eval and store the results on valid in a variable
+EVAL_RESULT=`sh run.sh | grep "Validation Metrics"`
+CLEANED_RESULT=`echo $EVAL_RESULT | sed 's/.*: //g' | sed 's/}.*//g'`
+TRAIN_RESULT=`cat output/results.txt`
+
+# Compare the two values, formatted to 5 decimal places
+if ! [ "$(printf "%.5f" "$EVAL_RESULT")" = "$(printf "%.5f" "$TRAIN_RESULT")" ]; then
+  echo "results are NOT equal up to 5 decimal places."
+  exit 1
+else
+  echo "results are equal."
+fi

--- a/tests/end2end_pytorch/run_single.sh
+++ b/tests/end2end_pytorch/run_single.sh
@@ -20,15 +20,15 @@ fi
 
 # now run eval and store the results on valid in a variable
 EVAL_RESULT=`sh run.sh | grep "Validation Metrics"`
-CLEANED_EVAL_RESULT=`echo $EVAL_RESULT | sed 's/.*: //g' | sed 's/}.*//g'`
-TRAIN_RESULT=`cat output/results.txt`
+#CLEANED_EVAL_RESULT=`echo $EVAL_RESULT | sed 's/.*: //g' | sed 's/}.*//g'`
+#TRAIN_RESULT=`cat output/results.txt`
 
-echo "train results: ${TRAIN_RESULT} / eval results: ${CLEANED_EVAL_RESULT}"
+#echo "train results: ${TRAIN_RESULT} / eval results: ${CLEANED_EVAL_RESULT}"
 
 # Compare the two values, formatted to 5 decimal places
-if ! [ "$(printf "%.5f" "$CLEANED_EVAL_RESULT")" = "$(printf "%.5f" "$TRAIN_RESULT")" ]; then
-  echo "results are NOT equal up to 5 decimal places."
-  exit 1
-else
-  echo "results are equal."
-fi
+#if ! [ "$(printf "%.5f" "$CLEANED_EVAL_RESULT")" = "$(printf "%.5f" "$TRAIN_RESULT")" ]; then
+#  echo "results are NOT equal up to 5 decimal places."
+#  exit 1
+#else
+#  echo "results are equal."
+#fi

--- a/tests/end2end_pytorch/run_single.sh
+++ b/tests/end2end_pytorch/run_single.sh
@@ -1,0 +1,19 @@
+# exit at the first error
+set -e
+
+# go to the examples folder and run the example
+cd $GITHUB_WORKSPACE/examples/local
+sh run.sh
+mv output output_OLD
+# re-run the example to check reproducibility
+sh run.sh
+# check results are the same
+echo "results are:"
+cat output*/results.txt
+DIFF_LINES=`cat output*/results.txt | uniq | wc -l`
+if [ ${DIFF_LINES} -gt 1 ]; then
+    echo "ERROR: two identical runs produced different output results - review seed implementation"
+    exit 1
+else
+    echo "PASS: two identical runs produced the same output results."
+fi

--- a/tests/end2end_pytorch/run_single.sh
+++ b/tests/end2end_pytorch/run_single.sh
@@ -19,16 +19,16 @@ else
 fi
 
 # now run eval and store the results on valid in a variable
-EVAL_RESULT=`sh run.sh | grep "Validation Metrics"`
-#CLEANED_EVAL_RESULT=`echo $EVAL_RESULT | sed 's/.*: //g' | sed 's/}.*//g'`
-#TRAIN_RESULT=`cat output/results.txt`
+EVAL_RESULT=`sh eval.sh | grep "Validation Metrics"`
+CLEANED_EVAL_RESULT=`echo $EVAL_RESULT | sed 's/.*: //g' | sed 's/}.*//g'`
+TRAIN_RESULT=`cat output/results.txt`
 
-#echo "train results: ${TRAIN_RESULT} / eval results: ${CLEANED_EVAL_RESULT}"
+echo "train results: ${TRAIN_RESULT} / eval results: ${CLEANED_EVAL_RESULT}"
 
 # Compare the two values, formatted to 5 decimal places
-#if ! [ "$(printf "%.5f" "$CLEANED_EVAL_RESULT")" = "$(printf "%.5f" "$TRAIN_RESULT")" ]; then
-#  echo "results are NOT equal up to 5 decimal places."
-#  exit 1
-#else
-#  echo "results are equal."
-#fi
+if ! [ "$(printf "%.5f" "$CLEANED_EVAL_RESULT")" = "$(printf "%.5f" "$TRAIN_RESULT")" ]; then
+  echo "results are NOT equal up to 5 decimal places."
+  exit 1
+else
+  echo "results are equal."
+fi

--- a/tests/end2end_pytorch/run_single.sh
+++ b/tests/end2end_pytorch/run_single.sh
@@ -22,11 +22,12 @@ fi
 EVAL_RESULT=`sh eval.sh | grep "Validation Metrics"`
 CLEANED_EVAL_RESULT=`echo $EVAL_RESULT | sed 's/.*: //g' | sed 's/}.*//g'`
 TRAIN_RESULT=`cat output/results.txt`
+CLEANED_TRAIN_RESULT=`echo TRAIN_RESULT | sed 's/.*: //g'`
 
-echo "train results: ${TRAIN_RESULT} / eval results: ${CLEANED_EVAL_RESULT}"
+echo "train results: ${CLEANED_TRAIN_RESULT} / eval results: ${CLEANED_EVAL_RESULT}"
 
 # Compare the two values, formatted to 5 decimal places
-if ! [ "$(printf "%.5f" "$CLEANED_EVAL_RESULT")" = "$(printf "%.5f" "$TRAIN_RESULT")" ]; then
+if ! [ "$(printf "%.5f" "$CLEANED_EVAL_RESULT")" = "$(printf "%.5f" "$CLEANED_TRAIN_RESULT")" ]; then
   echo "results are NOT equal up to 5 decimal places."
   exit 1
 else

--- a/tests/end2end_pytorch/run_single.sh
+++ b/tests/end2end_pytorch/run_single.sh
@@ -22,7 +22,7 @@ fi
 EVAL_RESULT=`sh eval.sh | grep "Validation Metrics"`
 CLEANED_EVAL_RESULT=`echo $EVAL_RESULT | sed 's/.*: //g' | sed 's/}.*//g'`
 TRAIN_RESULT=`cat output/results.txt`
-CLEANED_TRAIN_RESULT=`echo TRAIN_RESULT | sed 's/.*: //g'`
+CLEANED_TRAIN_RESULT=`echo ${TRAIN_RESULT} | sed 's/.*: //g'`
 
 echo "train results: ${CLEANED_TRAIN_RESULT} / eval results: ${CLEANED_EVAL_RESULT}"
 

--- a/tests/end2end_pytorch/run_single.sh
+++ b/tests/end2end_pytorch/run_single.sh
@@ -20,11 +20,13 @@ fi
 
 # now run eval and store the results on valid in a variable
 EVAL_RESULT=`sh run.sh | grep "Validation Metrics"`
-CLEANED_RESULT=`echo $EVAL_RESULT | sed 's/.*: //g' | sed 's/}.*//g'`
+CLEANED_EVAL_RESULT=`echo $EVAL_RESULT | sed 's/.*: //g' | sed 's/}.*//g'`
 TRAIN_RESULT=`cat output/results.txt`
 
+echo "train results: ${TRAIN_RESULT} / eval results: ${CLEANED_EVAL_RESULT}"
+
 # Compare the two values, formatted to 5 decimal places
-if ! [ "$(printf "%.5f" "$EVAL_RESULT")" = "$(printf "%.5f" "$TRAIN_RESULT")" ]; then
+if ! [ "$(printf "%.5f" "$CLEANED_EVAL_RESULT")" = "$(printf "%.5f" "$TRAIN_RESULT")" ]; then
   echo "results are NOT equal up to 5 decimal places."
   exit 1
 else


### PR DESCRIPTION
* the end2end test running all the pipeline is now split into two parts: single run and orion.
* the single run now also execute the evaluation part, and checks that the results are the same as for training (on valid).